### PR TITLE
Update for Debian 8.0 (jessie), 9.0 (stretch) and 10.0 (buster).

### DIFF
--- a/lib/Sys/Info/Driver/Linux/OS/Distribution/Conf.pm
+++ b/lib/Sys/Info/Driver/Linux/OS/Distribution/Conf.pm
@@ -47,24 +47,28 @@ our %CONF = Config::General::ParseConfig( -String => <<'RAW' );
            8.0  = jessie
            9.0  = stretch
           10.0  = buster
+          11.0  = bullseye
+          12.0  = bookworm
     </edition>
     # we get the version as "lenny/sid" for example
     <vfix>
-        buzz    = 1.1
-        rex     = 1.2
-        bo      = 1.3
-        hamm    = 2.0
-        slink   = 2.1
-        potato  = 2.2
-        woody   = 3.0
-        sarge   = 3.1
-        etch    = 4.0
-        lenny   = 5.0
-        squeeze = 6.0
-        wheezy  = 7.0
-        jessie  = 8.0
-        stretch = 9.0
-        buster  = 10.0
+        buzz     = 1.1
+        rex      = 1.2
+        bo       = 1.3
+        hamm     = 2.0
+        slink    = 2.1
+        potato   = 2.2
+        woody    = 3.0
+        sarge    = 3.1
+        etch     = 4.0
+        lenny    = 5.0
+        squeeze  = 6.0
+        wheezy   = 7.0
+        jessie   = 8.0
+        stretch  = 9.0
+        buster   = 10.0
+        bullseye = 11.0
+        bookworm = 12.0
     </vfix>
 </debian>
 

--- a/lib/Sys/Info/Driver/Linux/OS/Distribution/Conf.pm
+++ b/lib/Sys/Info/Driver/Linux/OS/Distribution/Conf.pm
@@ -31,8 +31,6 @@ our %CONF = Config::General::ParseConfig( -String => <<'RAW' );
 <debian>
     manufacturer  = Debian Project
     version_match = (.+)
-    release = debian_version
-    release = debian_release
     <edition>
            1.1  = buzz
            1.2  = rex
@@ -46,6 +44,9 @@ our %CONF = Config::General::ParseConfig( -String => <<'RAW' );
            5.0  = lenny
            6.0  = squeeze
            7.0  = wheezy
+           8.0  = jessie
+           9.0  = stretch
+          10.0  = buster
     </edition>
     # we get the version as "lenny/sid" for example
     <vfix>
@@ -61,6 +62,9 @@ our %CONF = Config::General::ParseConfig( -String => <<'RAW' );
         lenny   = 5.0
         squeeze = 6.0
         wheezy  = 7.0
+        jessie  = 8.0
+        stretch = 9.0
+        buster  = 10.0
     </vfix>
 </debian>
 


### PR DESCRIPTION
Also removed the obsolete debian_version and debian_release lines, as Distribution.pm no longer supports multiple release files and they made the tests fail (fixes issue #2 for Debian).