### PR TITLE
Fix for getting the OS version in RHEL* boxes.

### DIFF
--- a/lib/Sys/Info/Driver/Linux/OS/Distribution.pm
+++ b/lib/Sys/Info/Driver/Linux/OS/Distribution.pm
@@ -127,10 +127,6 @@ sub _probe_version {
                         ? $slot->{version_match}
                         : q{};
 
-    # There might be an override
-    local $self->{release_file} = $slot->{release}
-        if $slot->{release};
-
     my $vrelease = $self->_get_file_info;
 
     # Set to the original if we got any, othwerwise try the version

--- a/lib/Sys/Info/Driver/Linux/OS/Distribution/Conf.pm
+++ b/lib/Sys/Info/Driver/Linux/OS/Distribution/Conf.pm
@@ -20,7 +20,7 @@ our %CONF = Config::General::ParseConfig( -String => <<'RAW' );
 
 <centos>
     manufacturer  = Lance Davis
-    release       = redhat-release
+    release       = centos-release
     version_match = CentOS(?: Linux)? release (.*) \(
 </centos>
 


### PR DESCRIPTION
The current tests fail in RHEL boxes as they are unable to get the proper OS version.
