### PR TITLE
Update timezone handling to use /etc/localtime

### DIFF
--- a/lib/Sys/Info/Driver/Linux.pm
+++ b/lib/Sys/Info/Driver/Linux.pm
@@ -15,7 +15,7 @@ use constant proc => { ## no critic (NamingConventions::Capitalization)
     swaps    => '/proc/swaps',
     fstab    => '/etc/fstab',    # for filesystem type of the current disk
     resolv   => '/etc/resolv.conf',
-    timezone => '/etc/timezone',
+    timezone => '/etc/localtime',
     issue    => '/etc/issue',
 };
 

--- a/lib/Sys/Info/Driver/Linux/OS.pm
+++ b/lib/Sys/Info/Driver/Linux/OS.pm
@@ -28,8 +28,8 @@ sub edition {
 
 sub tz {
     my $self = shift;
-    return if ! -e proc->{timezone};
-    chomp( my $rv = $self->slurp( proc->{timezone} ) );
+    return if ! -l proc->{timezone};
+    chomp( my $rv = qx{readlink proc->{timezone} | sed 's|/usr/share/zoneinfo/||'} );
     return $rv;
 }
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Sys-Info-Driver-Linux.
We thought you might be interested in it too.

    Description: Update timezone handling to use /etc/localtime
     instead of /etc/timezone.
    Bug-Debian: https://bugs.debian.org/1038841
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2023-06-24
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libsys-info-driver-linux-perl/raw/master/debian/patches/etc_localtime.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
