### PR TITLE
Fix Debian 11 crash

### DIFF
--- a/lib/Sys/Info/Driver/Linux/OS/Distribution.pm
+++ b/lib/Sys/Info/Driver/Linux/OS/Distribution.pm
@@ -129,7 +129,10 @@ sub _probe_version {
 
     # There might be an override
     local $self->{release_file} = $slot->{release}
-        if $slot->{release};
+        if $slot->{release} && !ref($slot->{release});
+
+    local $self->{release_file} = $slot->{release}->[0]
+        if $slot->{release} && ref($slot->{release});
 
     my $vrelease = $self->_get_file_info;
 


### PR DESCRIPTION
Fixes:
```
Can't open /etc/ARRAY(0xaaaaeecb87d0): No such file or directory at /usr/local/share/perl/5.32.1/Sys/Info/Driver/Linux/OS.pm line 204.
```
This is actually an improvement over the proposed #5 as deleting the `local $self->{release_file}` completely would lead to a `(.*)` match for version ending up with the long OS name on my system become `Debian Linux pretty_name="debian gnu/linux 11 (bullseye) (kernel: 5.15.49-linuxkit)`. With this PR it becomes `Debian Linux 11.1 (kernel: 5.15.49-linuxkit)`.